### PR TITLE
FIX minPods failure when currentPods and queueMessages=0

### DIFF
--- a/autoscale.sh
+++ b/autoscale.sh
@@ -46,7 +46,7 @@ while true; do
         currentPods=$(getCurrentPods)
 
         if [[ $currentPods != "" ]]; then
-          if [[ $requiredPods -ne $currentPods ]]; then
+          if [[ $requiredPods -ne $currentPods || $currentPods -lt $minPods ]]; then
             desiredPods=""
             # Flag used to prevent scaling down or up if currentPods are already min or max respectively.
             scale=0


### PR DESCRIPTION
The minPods condition was not being respected when queue and current pods are equal to zero.
If minPods=1 and both queueMessages and currentPods are equal to ZERO, autoscale.sh would not run the minPods requirement.

This is a FIX for the ISSUE #11 . ;)